### PR TITLE
Add get transaction

### DIFF
--- a/src/commands/transaction/command.ts
+++ b/src/commands/transaction/command.ts
@@ -1,0 +1,3 @@
+import Program from "../../program.js";
+
+export default Program.command("transaction").description("get transaction hash for zkSync");

--- a/src/commands/transaction/deposit.ts
+++ b/src/commands/transaction/deposit.ts
@@ -1,0 +1,142 @@
+import inquirer from "inquirer";
+
+import Program from "./command.js";
+import {
+  amountOptionCreate,
+  chainOption,
+  l1RpcUrlOption,
+  l2RpcUrlOption,
+  privateKeyOption,
+  recipientOptionCreate,
+  zeekOption,
+} from "../../common/options.js";
+import { l2Chains } from "../../data/chains.js";
+import { ETH_TOKEN } from "../../utils/constants.js";
+import { bigNumberToDecimal, decimalToBigNumber } from "../../utils/formatters.js";
+import {
+  getAddressFromPrivateKey,
+  getL1Provider,
+  getL2Provider,
+  getL2Wallet,
+  optionNameToParam,
+} from "../../utils/helpers.js";
+import Logger from "../../utils/logger.js";
+import { isDecimalAmount, isAddress, isPrivateKey } from "../../utils/validators.js";
+import zeek from "../../utils/zeek.js";
+
+import type { DefaultTransferOptions } from "../../common/options.js";
+
+const amountOption = amountOptionCreate("deposit");
+const recipientOption = recipientOptionCreate("L2");
+
+type DepositOptions = DefaultTransferOptions;
+
+export const handler = async (options: DepositOptions) => {
+  try {
+    Logger.debug(
+      `Initial deposit options: ${JSON.stringify(
+        { ...options, ...(options.privateKey ? { privateKey: "<hidden>" } : {}) },
+        null,
+        2
+      )}`
+    );
+
+    const answers: DepositOptions = await inquirer.prompt(
+      [
+        {
+          message: chainOption.description,
+          name: optionNameToParam(chainOption.long!),
+          type: "list",
+          choices: l2Chains.filter((e) => e.l1Chain).map((e) => ({ name: e.name, value: e.network })),
+          required: true,
+          when(answers: DepositOptions) {
+            if (answers.l1RpcUrl && answers.l2RpcUrl) {
+              return false;
+            }
+            return true;
+          },
+        },
+        {
+          message: amountOption.description,
+          name: optionNameToParam(amountOption.long!),
+          type: "input",
+          required: true,
+          validate: (input: string) => isDecimalAmount(input),
+        },
+        {
+          message: privateKeyOption.description,
+          name: optionNameToParam(privateKeyOption.long!),
+          type: "password",
+          required: true,
+          validate: (input: string) => isPrivateKey(input),
+        },
+        {
+          message: recipientOption.description,
+          name: optionNameToParam(recipientOption.long!),
+          type: "input",
+          default: (answers: DepositOptions) => {
+            return getAddressFromPrivateKey(answers.privateKey);
+          },
+          required: true,
+          validate: (input: string) => isAddress(input),
+        },
+      ],
+      options
+    );
+
+    options = {
+      ...options,
+      ...answers,
+    };
+
+    Logger.debug(`Final deposit options: ${JSON.stringify({ ...options, privateKey: "<hidden>" }, null, 2)}`);
+
+    const fromChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
+    const fromChainLabel = fromChain && !options.l1RpcUrl ? fromChain.name : options.l1RpcUrl ?? "Unknown chain";
+    const toChain = l2Chains.find((e) => e.network === options.chain);
+    const toChainLabel = toChain && !options.l2RpcUrl ? toChain.name : options.l2RpcUrl ?? "Unknown chain";
+
+    Logger.info("\nDeposit:");
+    Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
+    Logger.info(` To: ${options.recipient} (${toChainLabel})`);
+    Logger.info(` Amount: ${bigNumberToDecimal(decimalToBigNumber(options.amount))} ETH`);
+
+    Logger.info("\nSending deposit transaction...");
+
+    const l1Provider = getL1Provider(options.l1RpcUrl ?? fromChain!.rpcUrl);
+    const l2Provider = getL2Provider(options.l2RpcUrl ?? toChain!.rpcUrl);
+    const senderWallet = getL2Wallet(options.privateKey, l2Provider, l1Provider);
+
+    const depositHandle = await senderWallet.deposit({
+      to: options.recipient,
+      token: ETH_TOKEN.l1Address,
+      amount: decimalToBigNumber(options.amount),
+    });
+    Logger.info("\nDeposit sent:");
+    Logger.info(` Transaction hash: ${depositHandle.hash}`);
+    if (fromChain?.explorerUrl) {
+      Logger.info(` Transaction link: ${fromChain.explorerUrl}/tx/${depositHandle.hash}`);
+    }
+
+    const senderBalance = await l1Provider.getBalance(senderWallet.address);
+    Logger.info(`\nSender L1 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
+
+    if (options.zeek) {
+      zeek();
+    }
+  } catch (error) {
+    Logger.error("There was an error while depositing funds:");
+    Logger.error(error);
+  }
+};
+
+Program.command("deposit")
+  .description("Transfer ETH from L1 to L2")
+  .addOption(amountOption)
+  .addOption(chainOption)
+  .addOption(recipientOption)
+  .addOption(l1RpcUrlOption)
+  .addOption(l2RpcUrlOption)
+  .addOption(privateKeyOption)
+  .addOption(zeekOption)
+  .action(handler);

--- a/src/commands/transaction/get-transaction.ts
+++ b/src/commands/transaction/get-transaction.ts
@@ -1,32 +1,15 @@
 import inquirer from "inquirer";
 
 import Program from "./command.js";
-import {
-  amountOptionCreate,
-  chainOption,
-  l1RpcUrlOption,
-  l2RpcUrlOption,
-  privateKeyOption,
-  recipientOptionCreate,
-  zeekOption,
-} from "../../common/options.js";
+import { chainOption } from "../../common/options.js";
 import { l2Chains } from "../../data/chains.js";
-import { ETH_TOKEN } from "../../utils/constants.js";
-import { bigNumberToDecimal, decimalToBigNumber } from "../../utils/formatters.js";
-import {
-  getAddressFromPrivateKey,
-  getL1Provider,
-  getL2Provider,
-  getL2Wallet,
-  optionNameToParam,
-} from "../../utils/helpers.js";
+import { optionNameToParam } from "../../utils/helpers.js";
 import { Provider } from "zksync-web3";
 import Logger from "../../utils/logger.js";
 import { isTransactionHash } from "../../utils/validators.js";
-import zeek from "../../utils/zeek.js";
 import { Option } from "commander";
 
-const transactionHashOption = new Option("--tx, --transaction <TX_HASH>", "get transaction by hash");
+const transactionHashOption = new Option("--tx-hash, --transaction-hash <TX_HASH>", "get transaction by hash");
 
 type GetTransactionOptions = {
   chain?: string;
@@ -46,7 +29,7 @@ export const handler = async (options: GetTransactionOptions) => {
         },
         {
           message: transactionHashOption.description,
-          name: optionNameToParam(transactionHashOption.long!),
+          name: "txHash",
           type: "input",
           required: true,
           validate: (input: string) => isTransactionHash(input),
@@ -60,45 +43,10 @@ export const handler = async (options: GetTransactionOptions) => {
       ...answers,
     };
 
-    const fromChain = l2Chains.find((e) => e.network === options.chain);
-    console.log(fromChain!.rpcUrl)
-    const l2Provider = new Provider();
+    const chain = l2Chains.find((e) => e.network === options.chain);
+    const l2Provider = new Provider(chain!.rpcUrl);
 
     console.log(await l2Provider.getTransactionDetails(String(options.txHash)));
-
-
-    /*const fromChainLabel = fromChain && !options.l2RpcUrl ? fromChain.name : options.l2RpcUrl ?? "Unknown chain";
-    const toChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
-    const toChainLabel = toChain && !options.l1RpcUrl ? toChain.name : options.l1RpcUrl ?? "Unknown chain";
-
-    Logger.info("\nWithdraw:");
-    Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
-    Logger.info(` To: ${options.recipient} (${toChainLabel})`);
-    Logger.info(` Amount: ${bigNumberToDecimal(decimalToBigNumber(options.amount))} ETH`);
-
-    Logger.info("\nSending withdraw transaction...");
-
-    const l1Provider = getL1Provider(options.l1RpcUrl ?? toChain!.rpcUrl);
-    const l2Provider = getL2Provider(options.l2RpcUrl ?? fromChain!.rpcUrl);
-    const senderWallet = getL2Wallet(options.privateKey, l2Provider, l1Provider);
-
-    const withdrawHandle = await senderWallet.withdraw({
-      to: options.recipient,
-      token: ETH_TOKEN.l1Address,
-      amount: decimalToBigNumber(options.amount),
-    });
-    Logger.info("\nWithdraw sent:");
-    Logger.info(` Transaction hash: ${withdrawHandle.hash}`);
-    if (fromChain?.explorerUrl) {
-      Logger.info(` Transaction link: ${fromChain.explorerUrl}/tx/${withdrawHandle.hash}`);
-    }
-
-    const senderBalance = await l2Provider.getBalance(senderWallet.address);
-    Logger.info(`\nSender L2 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
-
-    if (options.zeek) {
-      zeek();
-    }*/
   } catch (error) {
     Logger.error("There was an error while withdrawing funds:");
     Logger.error(error);

--- a/src/commands/transaction/get-transaction.ts
+++ b/src/commands/transaction/get-transaction.ts
@@ -1,0 +1,112 @@
+import inquirer from "inquirer";
+
+import Program from "./command.js";
+import {
+  amountOptionCreate,
+  chainOption,
+  l1RpcUrlOption,
+  l2RpcUrlOption,
+  privateKeyOption,
+  recipientOptionCreate,
+  zeekOption,
+} from "../../common/options.js";
+import { l2Chains } from "../../data/chains.js";
+import { ETH_TOKEN } from "../../utils/constants.js";
+import { bigNumberToDecimal, decimalToBigNumber } from "../../utils/formatters.js";
+import {
+  getAddressFromPrivateKey,
+  getL1Provider,
+  getL2Provider,
+  getL2Wallet,
+  optionNameToParam,
+} from "../../utils/helpers.js";
+import { Provider } from "zksync-web3";
+import Logger from "../../utils/logger.js";
+import { isTransactionHash } from "../../utils/validators.js";
+import zeek from "../../utils/zeek.js";
+import { Option } from "commander";
+
+const transactionHashOption = new Option("--tx, --transaction <TX_HASH>", "get transaction by hash");
+
+type GetTransactionOptions = {
+  chain?: string;
+  txHash?: string;
+}
+
+export const handler = async (options: GetTransactionOptions) => {
+  try {
+    const answers: GetTransactionOptions = await inquirer.prompt(
+      [
+        {
+          message: chainOption.description,
+          name: optionNameToParam(chainOption.long!),
+          type: "list",
+          choices: l2Chains.filter((e) => e.l1Chain).map((e) => ({ name: e.name, value: e.network })),
+          required: true,
+        },
+        {
+          message: transactionHashOption.description,
+          name: optionNameToParam(transactionHashOption.long!),
+          type: "input",
+          required: true,
+          validate: (input: string) => isTransactionHash(input),
+        },
+      ],
+      options
+    );
+
+    options = {
+      ...options,
+      ...answers,
+    };
+
+    const fromChain = l2Chains.find((e) => e.network === options.chain);
+    console.log(fromChain!.rpcUrl)
+    const l2Provider = new Provider();
+
+    console.log(await l2Provider.getTransactionDetails(String(options.txHash)));
+
+
+    /*const fromChainLabel = fromChain && !options.l2RpcUrl ? fromChain.name : options.l2RpcUrl ?? "Unknown chain";
+    const toChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
+    const toChainLabel = toChain && !options.l1RpcUrl ? toChain.name : options.l1RpcUrl ?? "Unknown chain";
+
+    Logger.info("\nWithdraw:");
+    Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
+    Logger.info(` To: ${options.recipient} (${toChainLabel})`);
+    Logger.info(` Amount: ${bigNumberToDecimal(decimalToBigNumber(options.amount))} ETH`);
+
+    Logger.info("\nSending withdraw transaction...");
+
+    const l1Provider = getL1Provider(options.l1RpcUrl ?? toChain!.rpcUrl);
+    const l2Provider = getL2Provider(options.l2RpcUrl ?? fromChain!.rpcUrl);
+    const senderWallet = getL2Wallet(options.privateKey, l2Provider, l1Provider);
+
+    const withdrawHandle = await senderWallet.withdraw({
+      to: options.recipient,
+      token: ETH_TOKEN.l1Address,
+      amount: decimalToBigNumber(options.amount),
+    });
+    Logger.info("\nWithdraw sent:");
+    Logger.info(` Transaction hash: ${withdrawHandle.hash}`);
+    if (fromChain?.explorerUrl) {
+      Logger.info(` Transaction link: ${fromChain.explorerUrl}/tx/${withdrawHandle.hash}`);
+    }
+
+    const senderBalance = await l2Provider.getBalance(senderWallet.address);
+    Logger.info(`\nSender L2 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
+
+    if (options.zeek) {
+      zeek();
+    }*/
+  } catch (error) {
+    Logger.error("There was an error while withdrawing funds:");
+    Logger.error(error);
+  }
+};
+
+Program.command("get-transaction")
+  .description("Get transaction by hash")
+  .addOption(chainOption)
+  .addOption(transactionHashOption)
+  .action(handler);

--- a/src/commands/transaction/index.ts
+++ b/src/commands/transaction/index.ts
@@ -1,0 +1,3 @@
+import "./get-transaction.js";
+
+import "./command.js"; // registers all the commands above

--- a/src/commands/transaction/withdraw-finalize.ts
+++ b/src/commands/transaction/withdraw-finalize.ts
@@ -1,0 +1,139 @@
+import { Option } from "commander";
+import inquirer from "inquirer";
+
+import Program from "./command.js";
+import { chainOption, l1RpcUrlOption, l2RpcUrlOption, privateKeyOption, zeekOption } from "../../common/options.js";
+import { l2Chains } from "../../data/chains.js";
+import { bigNumberToDecimal } from "../../utils/formatters.js";
+import {
+  getAddressFromPrivateKey,
+  getL1Provider,
+  getL2Provider,
+  getL2Wallet,
+  optionNameToParam,
+} from "../../utils/helpers.js";
+import Logger from "../../utils/logger.js";
+import { isPrivateKey, isTransactionHash } from "../../utils/validators.js";
+import zeek from "../../utils/zeek.js";
+
+import type { DefaultTransactionOptions } from "../../common/options.js";
+
+const transactionHashOption = new Option("--hash <transaction_hash>", "L2 withdrawal transaction hash to finalize");
+
+type WithdrawFinalizeOptions = DefaultTransactionOptions & {
+  hash: string;
+};
+
+export const handler = async (options: WithdrawFinalizeOptions) => {
+  try {
+    Logger.debug(
+      `Initial withdraw-finalize options: ${JSON.stringify(
+        { ...options, ...(options.privateKey ? { privateKey: "<hidden>" } : {}) },
+        null,
+        2
+      )}`
+    );
+
+    const answers: WithdrawFinalizeOptions = await inquirer.prompt(
+      [
+        {
+          message: chainOption.description,
+          name: optionNameToParam(chainOption.long!),
+          type: "list",
+          choices: l2Chains.filter((e) => e.l1Chain).map((e) => ({ name: e.name, value: e.network })),
+          required: true,
+          when(answers: WithdrawFinalizeOptions) {
+            if (answers.l1RpcUrl && answers.l2RpcUrl) {
+              return false;
+            }
+            return true;
+          },
+        },
+        {
+          message: transactionHashOption.description,
+          name: optionNameToParam(transactionHashOption.long!),
+          type: "input",
+          required: true,
+          validate: (input: string) => isTransactionHash(input),
+        },
+        {
+          message: privateKeyOption.description,
+          name: optionNameToParam(privateKeyOption.long!),
+          type: "password",
+          required: true,
+          validate: (input: string) => isPrivateKey(input),
+        },
+      ],
+      options
+    );
+
+    options = {
+      ...options,
+      ...answers,
+    };
+
+    Logger.debug(`Final withdraw-finalize options: ${JSON.stringify({ ...options, privateKey: "<hidden>" }, null, 2)}`);
+
+    const fromChain = l2Chains.find((e) => e.network === options.chain);
+    const fromChainLabel = fromChain && !options.l2RpcUrl ? fromChain.name : options.l2RpcUrl ?? "Unknown chain";
+    const toChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
+    const toChainLabel = toChain && !options.l1RpcUrl ? toChain.name : options.l1RpcUrl ?? "Unknown chain";
+
+    Logger.info("\nWithdraw finalize:");
+    Logger.info(` From chain: ${fromChainLabel}`);
+    Logger.info(` To chain: ${toChainLabel}`);
+    Logger.info(` Withdrawal transaction (L2): ${options.hash}`);
+    Logger.info(` Finalizer address (L1): ${getAddressFromPrivateKey(answers.privateKey)}`);
+
+    const l1Provider = getL1Provider(options.l1RpcUrl ?? toChain!.rpcUrl);
+    const l2Provider = getL2Provider(options.l2RpcUrl ?? fromChain!.rpcUrl);
+    const senderWallet = getL2Wallet(options.privateKey, l2Provider, l1Provider);
+
+    Logger.info("\nChecking status of the transaction...");
+    const l2Details = await l2Provider.getTransactionDetails(options.hash);
+    if (!l2Details) {
+      Logger.error("Transaction with specified hash wasn't found");
+      return;
+    }
+    if (!l2Details.ethExecuteTxHash) {
+      Logger.error(
+        `\nTransaction is still being processed on ${fromChainLabel}, please try again when the ethExecuteTxHash has been computed`
+      );
+      Logger.info(`L2 Transaction Details: ${JSON.stringify(l2Details, null, 2)}`);
+      return;
+    }
+    Logger.info("Transaction is ready to be finalized");
+
+    Logger.info("\nSending finalization transaction...");
+    const finalizationHandle = await senderWallet.finalizeWithdrawal(options.hash);
+    Logger.info("\nWithdrawal finalized:");
+    Logger.info(` Finalization transaction hash: ${finalizationHandle.hash}`);
+    if (toChain?.explorerUrl) {
+      Logger.info(` Transaction link: ${toChain.explorerUrl}/tx/${finalizationHandle.hash}`);
+    }
+
+    Logger.info("\nWaiting for finalization transaction to be mined...");
+    const receipt = await finalizationHandle.wait();
+    Logger.info(` Finalization transaction was mined in block ${receipt.blockNumber}`);
+
+    const senderBalance = await l1Provider.getBalance(senderWallet.address);
+    Logger.info(`\nSender L1 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
+
+    if (options.zeek) {
+      zeek();
+    }
+  } catch (error) {
+    Logger.error("There was an error while finalizing withdrawal:");
+    Logger.error(error);
+  }
+};
+
+Program.command("withdraw-finalize")
+  .description("Finalize withdrawal of funds")
+  .addOption(transactionHashOption)
+  .addOption(chainOption)
+  .addOption(l1RpcUrlOption)
+  .addOption(l2RpcUrlOption)
+  .addOption(privateKeyOption)
+  .addOption(zeekOption)
+  .action(handler);

--- a/src/commands/transaction/withdraw.ts
+++ b/src/commands/transaction/withdraw.ts
@@ -1,0 +1,142 @@
+import inquirer from "inquirer";
+
+import Program from "./command.js";
+import {
+  amountOptionCreate,
+  chainOption,
+  l1RpcUrlOption,
+  l2RpcUrlOption,
+  privateKeyOption,
+  recipientOptionCreate,
+  zeekOption,
+} from "../../common/options.js";
+import { l2Chains } from "../../data/chains.js";
+import { ETH_TOKEN } from "../../utils/constants.js";
+import { bigNumberToDecimal, decimalToBigNumber } from "../../utils/formatters.js";
+import {
+  getAddressFromPrivateKey,
+  getL1Provider,
+  getL2Provider,
+  getL2Wallet,
+  optionNameToParam,
+} from "../../utils/helpers.js";
+import Logger from "../../utils/logger.js";
+import { isDecimalAmount, isAddress, isPrivateKey } from "../../utils/validators.js";
+import zeek from "../../utils/zeek.js";
+
+import type { DefaultTransferOptions } from "../../common/options.js";
+
+const amountOption = amountOptionCreate("withdraw");
+const recipientOption = recipientOptionCreate("L1");
+
+type WithdrawOptions = DefaultTransferOptions;
+
+export const handler = async (options: WithdrawOptions) => {
+  try {
+    Logger.debug(
+      `Initial withdraw options: ${JSON.stringify(
+        { ...options, ...(options.privateKey ? { privateKey: "<hidden>" } : {}) },
+        null,
+        2
+      )}`
+    );
+
+    const answers: WithdrawOptions = await inquirer.prompt(
+      [
+        {
+          message: chainOption.description,
+          name: optionNameToParam(chainOption.long!),
+          type: "list",
+          choices: l2Chains.filter((e) => e.l1Chain).map((e) => ({ name: e.name, value: e.network })),
+          required: true,
+          when(answers: WithdrawOptions) {
+            if (answers.l1RpcUrl && answers.l2RpcUrl) {
+              return false;
+            }
+            return true;
+          },
+        },
+        {
+          message: amountOption.description,
+          name: optionNameToParam(amountOption.long!),
+          type: "input",
+          required: true,
+          validate: (input: string) => isDecimalAmount(input),
+        },
+        {
+          message: privateKeyOption.description,
+          name: optionNameToParam(privateKeyOption.long!),
+          type: "password",
+          required: true,
+          validate: (input: string) => isPrivateKey(input),
+        },
+        {
+          message: recipientOption.description,
+          name: optionNameToParam(recipientOption.long!),
+          type: "input",
+          default: (answers: WithdrawOptions) => {
+            return getAddressFromPrivateKey(answers.privateKey);
+          },
+          required: true,
+          validate: (input: string) => isAddress(input),
+        },
+      ],
+      options
+    );
+
+    options = {
+      ...options,
+      ...answers,
+    };
+
+    Logger.debug(`Final withdraw options: ${JSON.stringify({ ...options, privateKey: "<hidden>" }, null, 2)}`);
+
+    const fromChain = l2Chains.find((e) => e.network === options.chain);
+    const fromChainLabel = fromChain && !options.l2RpcUrl ? fromChain.name : options.l2RpcUrl ?? "Unknown chain";
+    const toChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
+    const toChainLabel = toChain && !options.l1RpcUrl ? toChain.name : options.l1RpcUrl ?? "Unknown chain";
+
+    Logger.info("\nWithdraw:");
+    Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
+    Logger.info(` To: ${options.recipient} (${toChainLabel})`);
+    Logger.info(` Amount: ${bigNumberToDecimal(decimalToBigNumber(options.amount))} ETH`);
+
+    Logger.info("\nSending withdraw transaction...");
+
+    const l1Provider = getL1Provider(options.l1RpcUrl ?? toChain!.rpcUrl);
+    const l2Provider = getL2Provider(options.l2RpcUrl ?? fromChain!.rpcUrl);
+    const senderWallet = getL2Wallet(options.privateKey, l2Provider, l1Provider);
+
+    const withdrawHandle = await senderWallet.withdraw({
+      to: options.recipient,
+      token: ETH_TOKEN.l1Address,
+      amount: decimalToBigNumber(options.amount),
+    });
+    Logger.info("\nWithdraw sent:");
+    Logger.info(` Transaction hash: ${withdrawHandle.hash}`);
+    if (fromChain?.explorerUrl) {
+      Logger.info(` Transaction link: ${fromChain.explorerUrl}/tx/${withdrawHandle.hash}`);
+    }
+
+    const senderBalance = await l2Provider.getBalance(senderWallet.address);
+    Logger.info(`\nSender L2 balance after transaction: ${bigNumberToDecimal(senderBalance)} ETH`);
+
+    if (options.zeek) {
+      zeek();
+    }
+  } catch (error) {
+    Logger.error("There was an error while withdrawing funds:");
+    Logger.error(error);
+  }
+};
+
+Program.command("withdraw")
+  .description("Transfer ETH from L2 to L1")
+  .addOption(amountOption)
+  .addOption(chainOption)
+  .addOption(recipientOption)
+  .addOption(l1RpcUrlOption)
+  .addOption(l2RpcUrlOption)
+  .addOption(privateKeyOption)
+  .addOption(zeekOption)
+  .action(handler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,6 @@ import "./commands/bridge/index.js";
 
 import "./commands/create/index.js";
 
+import "./commands/transaction/index.js";
+
 Program.parse();


### PR DESCRIPTION
# What :computer: 
Add `get-transaction` command

# Why :hand:
To get transaction data by it's hash

# Evidence :camera:
```bash
$> npm run dev transaction get-transaction

> zksync-cli@0.0.0-development dev
> ts-node-esm src/index.ts transaction get-transaction

? Chain to use Local Dockerized node
? get transaction by hash 0xb89858c34996a2afc747c8161502d7e1cc12e341307dd5b18daa93bcd1168df6
{
  isL1Originated: false,
  status: 'verified',
  fee: '0x48b8f6b15880',
  gasPerPubdata: '0x4e20',
  initiatorAddress: '0xbd29a1b981925b94eec5c4f1125af02a2ec4d1ca',
  receivedAt: '2023-11-27T13:15:39.876Z',
  ethCommitTxHash: '0x244b08981b29170f53232251f37f7b2622c29121cb4b2d9e1f10b545d263039e',
  ethProveTxHash: '0x97b1e5fa39fcd9cf2444ddf934364cb8cf611e58b0b5aa60d5eab3d24146d373',
  ethExecuteTxHash: '0x035b4da51f436b4a33c689a2196ab40e6173c6bfcfde52e5bc13e185d1cc5cb1'
}
```