### PR TITLE
Token flag for `withdraw` and `deposit` commands

### DIFF
--- a/src/commands/bridge/deposit.ts
+++ b/src/commands/bridge/deposit.ts
@@ -7,6 +7,7 @@ import {
   l1RpcUrlOption,
   l2RpcUrlOption,
   privateKeyOption,
+  tokenOption,
   recipientOptionCreate,
   zeekOption,
 } from "../../common/options.js";
@@ -95,6 +96,7 @@ export const handler = async (options: DepositOptions) => {
     const fromChainLabel = fromChain && !options.l1RpcUrl ? fromChain.name : options.l1RpcUrl ?? "Unknown chain";
     const toChain = l2Chains.find((e) => e.network === options.chain);
     const toChainLabel = toChain && !options.l2RpcUrl ? toChain.name : options.l2RpcUrl ?? "Unknown chain";
+    const token = options.token ?? ETH_TOKEN.l1Address;
 
     Logger.info("\nDeposit:");
     Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
@@ -109,7 +111,7 @@ export const handler = async (options: DepositOptions) => {
 
     const depositHandle = await senderWallet.deposit({
       to: options.recipient,
-      token: ETH_TOKEN.l1Address,
+      token: token,
       amount: decimalToBigNumber(options.amount),
     });
     Logger.info("\nDeposit sent:");
@@ -139,4 +141,5 @@ Program.command("deposit")
   .addOption(l2RpcUrlOption)
   .addOption(privateKeyOption)
   .addOption(zeekOption)
+  .addOption(tokenOption)
   .action(handler);

--- a/src/commands/bridge/withdraw.ts
+++ b/src/commands/bridge/withdraw.ts
@@ -8,6 +8,7 @@ import {
   l2RpcUrlOption,
   privateKeyOption,
   recipientOptionCreate,
+  tokenOption,
   zeekOption,
 } from "../../common/options.js";
 import { l2Chains } from "../../data/chains.js";
@@ -95,6 +96,7 @@ export const handler = async (options: WithdrawOptions) => {
     const fromChainLabel = fromChain && !options.l2RpcUrl ? fromChain.name : options.l2RpcUrl ?? "Unknown chain";
     const toChain = l2Chains.find((e) => e.network === options.chain)?.l1Chain;
     const toChainLabel = toChain && !options.l1RpcUrl ? toChain.name : options.l1RpcUrl ?? "Unknown chain";
+    const token = options.token ?? ETH_TOKEN.l1Address;
 
     Logger.info("\nWithdraw:");
     Logger.info(` From: ${getAddressFromPrivateKey(answers.privateKey)} (${fromChainLabel})`);
@@ -109,7 +111,7 @@ export const handler = async (options: WithdrawOptions) => {
 
     const withdrawHandle = await senderWallet.withdraw({
       to: options.recipient,
-      token: ETH_TOKEN.l1Address,
+      token: token,
       amount: decimalToBigNumber(options.amount),
     });
     Logger.info("\nWithdraw sent:");
@@ -138,5 +140,6 @@ Program.command("withdraw")
   .addOption(l1RpcUrlOption)
   .addOption(l2RpcUrlOption)
   .addOption(privateKeyOption)
+  .addOption(tokenOption)
   .addOption(zeekOption)
   .action(handler);

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -9,6 +9,7 @@ export const l1RpcUrlOption = new Option("--l1-rpc, --l1-rpc-url <URL>", "Overri
 export const l2RpcUrlOption = new Option("--l2-rpc, --l2-rpc-url <URL>", "Override L2 RPC URL");
 export const accountOption = new Option("--address, --address <ADDRESS>", "Account address");
 export const privateKeyOption = new Option("--pk, --private-key <URL>", "Private key of the sender");
+export const tokenOption = new Option("--t, --token <TOKEN_ADDRESS>", "Token to transfer");
 export const amountOptionCreate = (action: string) =>
   new Option("--a, --amount <amount>", `Amount of ETH to ${action} (eg. 0.1)`);
 export const recipientOptionCreate = (recipientLocation: string) =>
@@ -25,6 +26,7 @@ export type DefaultTransactionOptions = DefaultOptions & {
   chain?: string;
   l1RpcUrl?: string;
   l2RpcUrl?: string;
+  token?: string;
   privateKey: string;
 };
 export type DefaultTransferOptions = DefaultTransactionOptions & {


### PR DESCRIPTION
# What :computer: 
- New flag for `withdraw` and `deposit` commands to set a custom token address.

# Why :hand:
- Perform deposits and withdraws for an ERC20 deployed on L1 side.